### PR TITLE
fix: exclude auto-enriched text from completeness score

### DIFF
--- a/docs/data/catalog.json
+++ b/docs/data/catalog.json
@@ -243,7 +243,7 @@
         "model"
       ],
       "additional_resources": [],
-      "quality_score": 84
+      "quality_score": 69
     },
     {
       "id": "ui_5",
@@ -290,7 +290,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_6",
@@ -340,7 +340,7 @@
         "pilot"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 76
     },
     {
       "id": "ui_7",
@@ -445,7 +445,7 @@
           "url": "https://www.mozillafoundation.org/de/blog/lifting-up-women-through-land-ownership/"
         }
       ],
-      "quality_score": 93
+      "quality_score": 53
     },
     {
       "id": "ui_9",
@@ -542,7 +542,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_11",
@@ -681,7 +681,7 @@
         "usecase"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 76
     },
     {
       "id": "ui_13",
@@ -734,7 +734,7 @@
         "model"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     },
     {
       "id": "ui_14",
@@ -829,7 +829,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     },
     {
       "id": "ui_16",
@@ -875,7 +875,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_17",
@@ -922,7 +922,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 96
+      "quality_score": 56
     },
     {
       "id": "ui_18",
@@ -991,7 +991,7 @@
           "url": "https://g.co/kgs/5byh6f7"
         }
       ],
-      "quality_score": 100
+      "quality_score": 76
     },
     {
       "id": "ui_19",
@@ -1040,7 +1040,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     },
     {
       "id": "ui_21",
@@ -1112,7 +1112,7 @@
           "url": "https://smartafrica.org/innovate-africa-challenge/"
         }
       ],
-      "quality_score": 93
+      "quality_score": 68
     },
     {
       "id": "ui_22",
@@ -1242,7 +1242,7 @@
         "usecase"
       ],
       "additional_resources": [],
-      "quality_score": 96
+      "quality_score": 81
     },
     {
       "id": "ui_24",
@@ -2094,7 +2094,7 @@
           "url": "https://www.bmz-digital.global/en/entdeckung-der-sprachlichen-vielfalt-indonesiens-fair-forward-und-prosa-ai-auf-dem-weg-zu-inklusiver-ki-sprachtechnologie/"
         }
       ],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_38",
@@ -2154,7 +2154,7 @@
           "url": "https://www.giz.de/en/newsroom/stories/ai-climate-resilience-meets-local-know-how"
         }
       ],
-      "quality_score": 88
+      "quality_score": 73
     },
     {
       "id": "ui_39",
@@ -2203,7 +2203,7 @@
           "url": "https://www.recoftc.org/projects/advancing-oil-palm-mapping-social-forestry-and-machine-learning"
         }
       ],
-      "quality_score": 86
+      "quality_score": 61
     },
     {
       "id": "ui_40",
@@ -2461,7 +2461,7 @@
           "url": "https://datacollective.mozillafoundation.org/datasets?q=common+voice"
         }
       ],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_45",
@@ -2526,7 +2526,7 @@
           "url": "https://ieeexplore.ieee.org/document/11060524"
         }
       ],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_46",
@@ -2573,7 +2573,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_47",
@@ -2634,7 +2634,7 @@
           "url": "https://foundation.mozilla.org/blog/new-app-and-local-language-translations-improve-livestock-health-in-kenya-and-tanzania/"
         }
       ],
-      "quality_score": 93
+      "quality_score": 53
     },
     {
       "id": "ui_48",
@@ -2786,7 +2786,7 @@
         "usecase"
       ],
       "additional_resources": [],
-      "quality_score": 71
+      "quality_score": 61
     },
     {
       "id": "ui_51",
@@ -2849,7 +2849,7 @@
           "url": "https://www.bmz-digital.global/wp-content/uploads/2023/03/Creating-Community-Driven-Datasets-Report-032023-GIZ-Mozilla.pdf"
         }
       ],
-      "quality_score": 100
+      "quality_score": 76
     },
     {
       "id": "ui_52",
@@ -3003,7 +3003,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 93
+      "quality_score": 83
     },
     {
       "id": "ui_55",
@@ -3061,7 +3061,7 @@
           "url": "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5087469"
         }
       ],
-      "quality_score": 93
+      "quality_score": 38
     },
     {
       "id": "ui_56",
@@ -3126,7 +3126,7 @@
         "business"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_57",
@@ -3271,7 +3271,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     },
     {
       "id": "ui_60",
@@ -3332,7 +3332,7 @@
           "url": "https://www.bmz-digital.global/en/digital-maps-agriculture-rwanda/"
         }
       ],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_61",
@@ -4110,7 +4110,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 76
+      "quality_score": 61
     },
     {
       "id": "ui_75",
@@ -4458,7 +4458,7 @@
         "usecase"
       ],
       "additional_resources": [],
-      "quality_score": 93
+      "quality_score": 53
     },
     {
       "id": "ui_81",
@@ -4723,7 +4723,7 @@
         "pilot"
       ],
       "additional_resources": [],
-      "quality_score": 94
+      "quality_score": 69
     },
     {
       "id": "ui_87",
@@ -4795,7 +4795,7 @@
         "pilot"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     }
   ],
   "aliases": {

--- a/public/data/catalog.json
+++ b/public/data/catalog.json
@@ -243,7 +243,7 @@
         "model"
       ],
       "additional_resources": [],
-      "quality_score": 84
+      "quality_score": 69
     },
     {
       "id": "ui_5",
@@ -290,7 +290,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_6",
@@ -340,7 +340,7 @@
         "pilot"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 76
     },
     {
       "id": "ui_7",
@@ -445,7 +445,7 @@
           "url": "https://www.mozillafoundation.org/de/blog/lifting-up-women-through-land-ownership/"
         }
       ],
-      "quality_score": 93
+      "quality_score": 53
     },
     {
       "id": "ui_9",
@@ -542,7 +542,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_11",
@@ -681,7 +681,7 @@
         "usecase"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 76
     },
     {
       "id": "ui_13",
@@ -734,7 +734,7 @@
         "model"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     },
     {
       "id": "ui_14",
@@ -829,7 +829,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     },
     {
       "id": "ui_16",
@@ -875,7 +875,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_17",
@@ -922,7 +922,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 96
+      "quality_score": 56
     },
     {
       "id": "ui_18",
@@ -991,7 +991,7 @@
           "url": "https://g.co/kgs/5byh6f7"
         }
       ],
-      "quality_score": 100
+      "quality_score": 76
     },
     {
       "id": "ui_19",
@@ -1040,7 +1040,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     },
     {
       "id": "ui_21",
@@ -1112,7 +1112,7 @@
           "url": "https://smartafrica.org/innovate-africa-challenge/"
         }
       ],
-      "quality_score": 93
+      "quality_score": 68
     },
     {
       "id": "ui_22",
@@ -1242,7 +1242,7 @@
         "usecase"
       ],
       "additional_resources": [],
-      "quality_score": 96
+      "quality_score": 81
     },
     {
       "id": "ui_24",
@@ -2094,7 +2094,7 @@
           "url": "https://www.bmz-digital.global/en/entdeckung-der-sprachlichen-vielfalt-indonesiens-fair-forward-und-prosa-ai-auf-dem-weg-zu-inklusiver-ki-sprachtechnologie/"
         }
       ],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_38",
@@ -2154,7 +2154,7 @@
           "url": "https://www.giz.de/en/newsroom/stories/ai-climate-resilience-meets-local-know-how"
         }
       ],
-      "quality_score": 88
+      "quality_score": 73
     },
     {
       "id": "ui_39",
@@ -2203,7 +2203,7 @@
           "url": "https://www.recoftc.org/projects/advancing-oil-palm-mapping-social-forestry-and-machine-learning"
         }
       ],
-      "quality_score": 86
+      "quality_score": 61
     },
     {
       "id": "ui_40",
@@ -2461,7 +2461,7 @@
           "url": "https://datacollective.mozillafoundation.org/datasets?q=common+voice"
         }
       ],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_45",
@@ -2526,7 +2526,7 @@
           "url": "https://ieeexplore.ieee.org/document/11060524"
         }
       ],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_46",
@@ -2573,7 +2573,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_47",
@@ -2634,7 +2634,7 @@
           "url": "https://foundation.mozilla.org/blog/new-app-and-local-language-translations-improve-livestock-health-in-kenya-and-tanzania/"
         }
       ],
-      "quality_score": 93
+      "quality_score": 53
     },
     {
       "id": "ui_48",
@@ -2786,7 +2786,7 @@
         "usecase"
       ],
       "additional_resources": [],
-      "quality_score": 71
+      "quality_score": 61
     },
     {
       "id": "ui_51",
@@ -2849,7 +2849,7 @@
           "url": "https://www.bmz-digital.global/wp-content/uploads/2023/03/Creating-Community-Driven-Datasets-Report-032023-GIZ-Mozilla.pdf"
         }
       ],
-      "quality_score": 100
+      "quality_score": 76
     },
     {
       "id": "ui_52",
@@ -3003,7 +3003,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 93
+      "quality_score": 83
     },
     {
       "id": "ui_55",
@@ -3061,7 +3061,7 @@
           "url": "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5087469"
         }
       ],
-      "quality_score": 93
+      "quality_score": 38
     },
     {
       "id": "ui_56",
@@ -3126,7 +3126,7 @@
         "business"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_57",
@@ -3271,7 +3271,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     },
     {
       "id": "ui_60",
@@ -3332,7 +3332,7 @@
           "url": "https://www.bmz-digital.global/en/digital-maps-agriculture-rwanda/"
         }
       ],
-      "quality_score": 100
+      "quality_score": 91
     },
     {
       "id": "ui_61",
@@ -4110,7 +4110,7 @@
         "dataset"
       ],
       "additional_resources": [],
-      "quality_score": 76
+      "quality_score": 61
     },
     {
       "id": "ui_75",
@@ -4458,7 +4458,7 @@
         "usecase"
       ],
       "additional_resources": [],
-      "quality_score": 93
+      "quality_score": 53
     },
     {
       "id": "ui_81",
@@ -4723,7 +4723,7 @@
         "pilot"
       ],
       "additional_resources": [],
-      "quality_score": 94
+      "quality_score": 69
     },
     {
       "id": "ui_87",
@@ -4795,7 +4795,7 @@
         "pilot"
       ],
       "additional_resources": [],
-      "quality_score": 100
+      "quality_score": 61
     }
   ],
   "aliases": {

--- a/scripts/enrich_data.py
+++ b/scripts/enrich_data.py
@@ -42,6 +42,7 @@ from utils import (
     extract_http_links,
     resolve_project_id,
     DEFAULT_CREDENTIALS_PATH,
+    AUTO_ENRICHED_PREFIX,
 )
 
 # Inlined from generate_catalog_data.py to avoid its module-level argparse
@@ -1115,7 +1116,10 @@ def generate_enrichment_report(results, freshness_data, cross_ref_mismatches,
 # Sheet writing (direct cell writes with disclaimer)
 # ---------------------------------------------------------------------------
 
-CELL_DISCLAIMER = "[Auto-enriched from linked project resources]\n\n"
+# Disclaimer text written into auto-filled cells. Detection lives in
+# utils.is_auto_enriched(); both sides share AUTO_ENRICHED_PREFIX so the
+# write path and the read path cannot drift.
+CELL_DISCLAIMER = AUTO_ENRICHED_PREFIX + "\n\n"
 
 
 def write_enrichment_to_sheet(results, discovered_resources,

--- a/scripts/generate_catalog_data.py
+++ b/scripts/generate_catalog_data.py
@@ -13,6 +13,7 @@ from utils import (
     extract_links_allow_site_paths,
     merge_access_note_link_columns,
     documents_dir_has_files,
+    is_auto_enriched,
 )
 
 # Parse command line arguments
@@ -85,31 +86,18 @@ def clean_country_list(country_text):
     return countries
 
 
-# Marker written by scripts/enrich_data.py (CELL_DISCLAIMER) for auto-filled
-# text fields. Values that begin with this prefix are treated as empty for
-# scoring purposes, so auto-enrichment never inflates a project's completeness
-# rank on the catalog page. Editing the cell to remove the prefix re-qualifies
-# the content as user-authored.
-AUTO_ENRICHED_PREFIX = "[Auto-enriched from linked project resources]"
-
-
-def _is_auto_enriched(text):
-    if not isinstance(text, str):
-        return False
-    return text.lstrip().startswith(AUTO_ENRICHED_PREFIX)
-
-
 def _content_length_score(text, thresholds):
-    """Graduated score based on content length.
+    """Graduated score based on length of human-authored content.
 
     thresholds: list of (min_chars, points) tuples, cumulative.
     Returns sum of points for all thresholds where len(text) >= min_chars.
     Auto-enriched content is treated as empty (returns 0) so it does not
-    inflate the project's completeness rank.
+    inflate the project's completeness rank. Editing the cell to remove
+    the auto-enrichment prefix re-qualifies the content as user-authored.
     """
     if not text or not isinstance(text, str):
         return 0
-    if _is_auto_enriched(text):
+    if is_auto_enriched(text):
         return 0
     length = len(text.strip())
     if length == 0:

--- a/scripts/generate_catalog_data.py
+++ b/scripts/generate_catalog_data.py
@@ -85,13 +85,31 @@ def clean_country_list(country_text):
     return countries
 
 
+# Marker written by scripts/enrich_data.py (CELL_DISCLAIMER) for auto-filled
+# text fields. Values that begin with this prefix are treated as empty for
+# scoring purposes, so auto-enrichment never inflates a project's completeness
+# rank on the catalog page. Editing the cell to remove the prefix re-qualifies
+# the content as user-authored.
+AUTO_ENRICHED_PREFIX = "[Auto-enriched from linked project resources]"
+
+
+def _is_auto_enriched(text):
+    if not isinstance(text, str):
+        return False
+    return text.lstrip().startswith(AUTO_ENRICHED_PREFIX)
+
+
 def _content_length_score(text, thresholds):
     """Graduated score based on content length.
 
     thresholds: list of (min_chars, points) tuples, cumulative.
     Returns sum of points for all thresholds where len(text) >= min_chars.
+    Auto-enriched content is treated as empty (returns 0) so it does not
+    inflate the project's completeness rank.
     """
     if not text or not isinstance(text, str):
+        return 0
+    if _is_auto_enriched(text):
         return 0
     length = len(text.strip())
     if length == 0:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -54,6 +54,20 @@ def normalize_sheet_link_cell(value):
     return value.strip()
 
 
+# Marker prefix used by scripts/enrich_data.py when auto-filling empty cells
+# with text extracted from linked project resources. Kept here as the single
+# source of truth so scripts/generate_catalog_data.py (scoring/detection) and
+# scripts/enrich_data.py (writing) cannot drift apart.
+AUTO_ENRICHED_PREFIX = "[Auto-enriched from linked project resources]"
+
+
+def is_auto_enriched(text):
+    """True if text begins with the AUTO_ENRICHED_PREFIX marker."""
+    if not isinstance(text, str):
+        return False
+    return text.lstrip().startswith(AUTO_ENRICHED_PREFIX)
+
+
 _DANGEROUS_SCHEMES = ('javascript:', 'data:', 'vbscript:', 'file:')
 
 


### PR DESCRIPTION
## Summary

Auto-enriched text fields were silently inflating `quality_score` and pushing those projects to the top of the catalog leaderboard. This change makes the score reflect human-curated depth only.

`scripts/generate_catalog_data.py:_content_length_score` now treats any value beginning with the disclaimer prefix written by `enrich_data.py` (`CELL_DISCLAIMER = "[Auto-enriched from linked project resources]"`) as empty. This applies to the four graduated text fields:

- `description` (max 15 pts)
- `data_characteristics` (max 15 pts)
- `model_characteristics` (max 10 pts)
- `how_to_use` (max 15 pts)

When a curator edits a cell and removes the prefix line, the content automatically re-qualifies as user-authored and starts counting again — no metadata flag needed.

## Known gap

`license` is also auto-enrichable but `enrich_data.py` writes it without a marker (treated as structured data), so auto-enriched licenses still contribute their 8 points. Documented inline; can be addressed separately if it becomes a problem.

## Impact (regenerated `catalog.json`)

| Metric | Before | After |
|---|---|---|
| Projects at score 100 | 25 | 7 |
| Projects 50–69 | 22 | 37 |
| Projects unchanged | — | 54 |
| Projects that lost points | — | 32 |
| Projects that gained points | — | **0** |

Worst case `ui_55` (all four text fields auto-enriched): 93 → 38 (−55), exactly as predicted by the scoring math. `ui_8 / ui_17 / ui_47 / ui_80` (four-field tier): −40 each.

## Test plan

- [x] `python scripts/generate_catalog_data.py` regenerates `public/data/catalog.json` with the new scores
- [x] `npm run build` succeeds and updates `docs/data/catalog.json` to match
- [x] Diff before/after confirms 0 score gains, only auto-enriched projects affected
- [x] Spot-check `ui_55` score in both `public/data/catalog.json` and `docs/data/catalog.json` = 38
- [ ] Reviewer: open the dev server (`npm run dev`) and confirm auto-enriched-only projects appear lower with fewer information-depth dots, while detail panels still show the auto-enriched text exactly as before