### PR TITLE
Fix health check workflow: install pandas

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: "3.x"
 
     - name: Install dependencies
-      run: pip install requests
+      run: pip install requests pandas
 
     - name: Run health check
       env:


### PR DESCRIPTION
## Summary

- The health check workflow crashed with `ModuleNotFoundError: No module named 'pandas'`
- `health_check.py` imports `check_urls` from `utils.py`, which imports pandas at module level
- The workflow's install step only included `requests`, missing the pandas dependency

## Fix

Added `pandas` to the `pip install` step in `.github/workflows/health_check.yml`.

## Test plan

- [ ] Merge this PR
- [ ] Trigger the "Weekly Health Check" workflow manually from the Actions tab to confirm it runs to completion