### PR TITLE
Fix auto-merge for automated PRs

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -57,4 +57,9 @@ jobs:
           --body "Automated weekly link health check results." \
           --base main
         PR_NUM=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
-        gh pr merge "$PR_NUM" --squash --auto || echo "::notice::Auto-merge not available. PR #$PR_NUM needs manual merge."
+        # Enable auto-merge (queues behind required checks, if any are ever added). When the
+        # PR is already mergeable, GitHub rejects --auto with "clean status", so fall back to
+        # an immediate squash merge.
+        gh pr merge "$PR_NUM" --squash --auto \
+          || gh pr merge "$PR_NUM" --squash \
+          || echo "::notice::Merge failed. PR #$PR_NUM needs manual merge."

--- a/.github/workflows/revert_last_update.yml
+++ b/.github/workflows/revert_last_update.yml
@@ -54,7 +54,12 @@ jobs:
           --base main
 
         PR_NUM=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
-        gh pr merge "$PR_NUM" --squash --auto || echo "::notice::Auto-merge not available. PR #$PR_NUM needs manual merge."
+        # Enable auto-merge (queues behind required checks, if any are ever added). When the
+        # PR is already mergeable, GitHub rejects --auto with "clean status", so fall back to
+        # an immediate squash merge.
+        gh pr merge "$PR_NUM" --squash --auto \
+          || gh pr merge "$PR_NUM" --squash \
+          || echo "::notice::Merge failed. PR #$PR_NUM needs manual merge."
 
         echo "Revert PR #$PR_NUM created."
         echo "The website will return to its previous state once the PR is merged and GitHub Pages rebuilds."

--- a/.github/workflows/update_from_google_sheets.yml
+++ b/.github/workflows/update_from_google_sheets.yml
@@ -134,7 +134,11 @@ jobs:
           TITLE="Sheet update $(date -u +'%Y-%m-%d') (auto-merge)"
           gh pr create --title "$TITLE" --body-file change_summary.md --base main
           PR_NUM=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
-          # Auto-merge if branch protection is configured; skip gracefully if not
-          gh pr merge "$PR_NUM" --squash --auto || echo "::notice::Auto-merge not available. PR #$PR_NUM needs manual merge."
+          # Enable auto-merge (queues behind required checks, if any are ever added). When the
+          # PR is already mergeable, GitHub rejects --auto with "clean status", so fall back to
+          # an immediate squash merge.
+          gh pr merge "$PR_NUM" --squash --auto \
+            || gh pr merge "$PR_NUM" --squash \
+            || echo "::notice::Merge failed. PR #$PR_NUM needs manual merge."
           echo "PR #$PR_NUM created."
         fi


### PR DESCRIPTION
## Problem

Automated PRs (sheet updates from the trigger button, weekly health checks, reverts) were not auto-merging and had to be merged manually.

## Root cause

The `main-protection` ruleset requires PRs but defines **no required status checks** and **no required approvals**. That makes every automated PR immediately mergeable — and GitHub's API rejects `gh pr merge --auto` on an already-mergeable PR (error: "Pull request is in clean status"). The existing `|| echo "needs manual merge"` fallback then fired, leaving the PR open.

## Fix

In all three automated workflows, fall back to an immediate squash merge when `--auto` is rejected:

```bash
gh pr merge "$PR_NUM" --squash --auto \
  || gh pr merge "$PR_NUM" --squash \
  || echo "::notice::Merge failed. PR #$PR_NUM needs manual merge."
```

This is robust to both states: if required checks are ever added, `--auto` queues the PR behind them; with no checks (current state), the immediate merge runs.

## Note

This PR itself must be merged manually (it carries the fix). After it lands, future automated PRs will merge themselves.