### PR TITLE
Add Google Search Console verification file

### DIFF
--- a/docs/googlede28baee9b71a518.html
+++ b/docs/googlede28baee9b71a518.html
@@ -1,0 +1,1 @@
+google-site-verification: googlede28baee9b71a518.html

--- a/public/googlede28baee9b71a518.html
+++ b/public/googlede28baee9b71a518.html
@@ -1,0 +1,1 @@
+google-site-verification: googlede28baee9b71a518.html


### PR DESCRIPTION
Adds the Google-provided site-verification file so we can verify ownership of the site in Google Search Console and submit the sitemap.

Serves at https://fair-forward.github.io/datasets/googlede28baee9b71a518.html (placed in both public/ and docs/ so it survives future builds). Follow-up to #114; the file must stay in the repo permanently, as Google re-checks it.